### PR TITLE
FIX: typo in React Native course

### DIFF
--- a/docs/react-native-course/expo-router/README.md
+++ b/docs/react-native-course/expo-router/README.md
@@ -44,9 +44,9 @@ Pas de `main` property in je `package.json` aan:
 
 #### App.js aanpassen
 
-Pas je `App.js` aan:
+Pas je `App.json` aan:
 
-```jsx
+```json
 {
   ...
   "scheme": "your-app-scheme"

--- a/docs/react-native-course/expo-router/README.md
+++ b/docs/react-native-course/expo-router/README.md
@@ -42,7 +42,7 @@ Pas de `main` property in je `package.json` aan:
 }
 ```
 
-#### App.js aanpassen
+#### App.json aanpassen
 
 Pas je `App.json` aan:
 


### PR DESCRIPTION
Met dit pull-verzoek wordt een kleine typefout in `docs/react-native-course/expo-router/README.md` verholpen.  De wijziging is eenvoudig en heeft geen invloed op de algehele functionaliteit van de code... normaal gezien.

Veranderingen gemaakt:

De typefout in regel 45 & 47 gecorrigeerd van "App.js" naar "App.json".